### PR TITLE
removes useless markup for correcting a display bug

### DIFF
--- a/Resources/views/BusinessRight/edit.html.twig
+++ b/Resources/views/BusinessRight/edit.html.twig
@@ -49,11 +49,9 @@
 {% endblock %}
 
 {% block left_menu -%}
-<div class="row">
-    <div class="list-group">
-        {% for application in applications %}
-            <a href="{{ path('sam_security_business_right_edit', { 'appId':application.id }) }}"class="list-group-item {% if appId == application.id %} active {% endif %}">{{ application.name }}</a>
-        {% endfor %}
-    </div>
+<div class="list-group">
+    {% for application in applications %}
+        <a href="{{ path('sam_security_business_right_edit', { 'appId':application.id }) }}"class="list-group-item {% if appId == application.id %} active {% endif %}">{{ application.name }}</a>
+    {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
A small fix for correcting a bug display on permission page. There was an horizontal scrollbar at the bottom of the application submenu.

![capture_bugihm](https://cloud.githubusercontent.com/assets/1296439/17438952/da4f52e8-5b25-11e6-8334-cba731c0cc19.png)
