### PR TITLE
made symfony3 compatible

### DIFF
--- a/Controller/BusinessRightController.php
+++ b/Controller/BusinessRightController.php
@@ -5,6 +5,7 @@ namespace CanalTP\SamEcoreSecurityBundle\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\ApplicationRoleType;
+use CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\BusinessRightType;
 
 class BusinessRightController extends Controller
 {
@@ -29,7 +30,7 @@ class BusinessRightController extends Controller
     private function buildForm($application)
     {
         $form = $this->createForm(
-            new ApplicationRoleType(),
+            ApplicationRoleType::class,
             $application,
             array(
                 'action' => $this->generateUrl(
@@ -51,7 +52,7 @@ class BusinessRightController extends Controller
         $em = $this->getDoctrine()->getManager();
         $application = $em->getRepository('CanalTPSamCoreBundle:Application')
             ->findWithEditableRoles($appId);
-        
+
         if (!$application) {
             throw new LogicException(sprintf("Application with id (%d) not found", $appId));
         }
@@ -62,7 +63,7 @@ class BusinessRightController extends Controller
         if ($render) {
             $form = $this->buildForm($application);
         }
-        
+
         return $this->render(
             'CanalTPSamEcoreSecurityBundle:BusinessRight:edit.html.twig',
             array(

--- a/Controller/RoleController.php
+++ b/Controller/RoleController.php
@@ -7,6 +7,9 @@ use CanalTP\SamCoreBundle\Controller\AbstractController;
 
 use CanalTP\SamCoreBundle\Entity\Role;
 use CanalTP\SamEcoreSecurityBundle\Form\Model\RegistrationRole;
+use CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CreateRoleType;
+use CanalTP\SamEcoreSecurityBundle\Form\Type\Role\RoleType;
+
 
 /**
  * Role controller.
@@ -41,7 +44,7 @@ class RoleController extends AbstractController
     */
     private function createCreateForm(RegistrationRole $entity)
     {
-        $form = $this->createForm('sam_create_role', $entity, array(
+        $form = $this->createForm(CreateRoleType::class, $entity, array(
             'action' => $this->generateUrl('sam_role_create'),
             'method' => 'POST'
         ));
@@ -140,7 +143,7 @@ class RoleController extends AbstractController
     */
     private function createEditForm(Role $entity)
     {
-        $form = $this->createForm('sam_role', $entity, array(
+        $form = $this->createForm(RoleType::class, $entity, array(
             'action' => $this->generateUrl('sam_role_update', array('id' => $entity->getId())),
             'method' => 'PUT',
         ));

--- a/Form/EventListener/CreateRoleListener.php
+++ b/Form/EventListener/CreateRoleListener.php
@@ -10,7 +10,7 @@ namespace CanalTP\SamEcoreSecurityBundle\Form\EventListener;
 
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -21,6 +21,7 @@ use CanalTP\SamCoreBundle\Entity\Role;
 use CanalTP\SamCoreBundle\Entity\UserApplicationRole;
 use CanalTP\SamCoreBundle\Entity\Application;
 use CanalTP\SamCoreBundle\CanalTPSamCoreBundle;
+use CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CopyRoleByApplicationType;
 
 class CreateRoleListener implements EventSubscriberInterface
 {
@@ -48,14 +49,18 @@ class CreateRoleListener implements EventSubscriberInterface
 
         $form->add(
             'applications',
-            'choice',
+            ChoiceType::class,
             array(
-                'label'       => 'role.field.application',
-                'multiple'    => true,
-                'expanded'    => true,
-                'required'    => false,
-                'choice_list' => new ObjectChoiceList($applications, 'name'),
-                'constraints' => array(new NotBlank())
+                'label'             => 'role.field.application',
+                'multiple'          => true,
+                'expanded'          => true,
+                'required'          => false,
+                'choices'           => $applications,
+                'choices_as_values' => true,
+                'choice_label' => function ($app, $key, $index) {
+                    return $app->getName();
+                },
+                'constraints'       => array(new NotBlank())
             )
         );
 
@@ -64,7 +69,7 @@ class CreateRoleListener implements EventSubscriberInterface
             'collection',
             array(
                 'label'        => 'role.field.parent.label',
-                'type'         => 'sam_copy_role_by_application',
+                'type'         => CopyRoleByApplicationType::class,
                 'allow_add'    => false,
                 'allow_delete' => false,
                 'by_reference' => false,

--- a/Form/Type/Permission/ApplicationRoleType.php
+++ b/Form/Type/Permission/ApplicationRoleType.php
@@ -6,7 +6,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\BusinessRightType;
 
 class ApplicationRoleType extends AbstractType
 {
@@ -18,30 +19,22 @@ class ApplicationRoleType extends AbstractType
     {
         $builder->add('roles', 'collection',
             array(
-                'type' => 'sam_business_right',
+                'type' => BusinessRightType::class,
                 'options' => array('application' => $builder->getData()),
             )
         );
-        
+
         $builder->setAction($options['action']);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'CanalTP\SamCoreBundle\Entity\Application',
             'attr' => array('novalidate' => 'novalidate')
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sam_application_right';
     }
 }

--- a/Form/Type/Role/CopyRoleByApplicationType.php
+++ b/Form/Type/Role/CopyRoleByApplicationType.php
@@ -4,7 +4,7 @@ namespace CanalTP\SamEcoreSecurityBundle\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Doctrine\ORM\EntityRepository;
@@ -55,20 +55,12 @@ class CopyRoleByApplicationType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'CanalTP\SamCoreBundle\Entity\Application'
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sam_copy_role_by_application';
     }
 }

--- a/Form/Type/Role/CreateRoleType.php
+++ b/Form/Type/Role/CreateRoleType.php
@@ -4,8 +4,8 @@ namespace CanalTP\SamEcoreSecurityBundle\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use CanalTP\SamEcoreSecurityBundle\Form\Type\RoleType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use CanalTP\SamEcoreSecurityBundle\Form\Type\Role\RoleType;
 
 /**
  * Description of RoleType
@@ -27,26 +27,18 @@ class CreateRoleType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('role', 'sam_role');
+        $builder->add('role', RoleType::class);
 
         $builder->addEventSubscriber($this->roleListener);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'CanalTP\SamEcoreSecurityBundle\Form\Model\RegistrationRole'
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sam_create_role';
     }
 }

--- a/Form/Type/Role/RoleType.php
+++ b/Form/Type/Role/RoleType.php
@@ -4,7 +4,7 @@ namespace CanalTP\SamEcoreSecurityBundle\Form\Type\Role;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -34,20 +34,12 @@ class RoleType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'CanalTP\SamCoreBundle\Entity\Role'
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sam_role';
     }
 }

--- a/Resources/config/permission.yml
+++ b/Resources/config/permission.yml
@@ -1,11 +1,8 @@
-parameters:
-    sam_business_right.type.class: CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\BusinessRightType
-
 services:
     sam_business_right.type:
-        class: %sam_business_right.type.class%
+        class: "CanalTP\\SamEcoreSecurityBundle\\Form\\Type\\Permission\\BusinessRightType"
         arguments:
            - '@sam.business_component'
            - @security.context
         tags:
-            - { name: form.type, alias: sam_business_right }
+            - { name: form.type }

--- a/Resources/config/role.yml
+++ b/Resources/config/role.yml
@@ -1,30 +1,19 @@
-parameters:
-    sam_create_role.type.class: CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CreateRoleType
-    sam_role.type.class: CanalTP\SamEcoreSecurityBundle\Form\Type\Role\RoleType
-    sam_create_role_listener.class: CanalTP\SamEcoreSecurityBundle\Form\EventListener\CreateRoleListener
-    sam_copy_role_by_application.type.class: CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CopyRoleByApplicationType
-
 services:
     sam_create_role.type:
-        class: %sam_create_role.type.class%
+        class: "CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CreateRoleType"
         arguments:
            - '@sam_create_role_listener'
         tags:
-            - { name: form.type, alias: sam_create_role }
-
-    sam_role.type:
-        class: %sam_role.type.class%
-        tags:
-            - { name: form.type, alias: sam_role }
+            - { name: form.type }
 
     sam_create_role_listener:
-        class: %sam_create_role_listener.class%
+        class: "CanalTP\SamEcoreSecurityBundle\Form\EventListener\CreateRoleListener"
         arguments:
            - '@doctrine.orm.entity_manager'
 
     sam_copy_role_by_application.type:
-        class: %sam_copy_role_by_application.type.class%
+        class: "CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CopyRoleByApplicationType"
         arguments:
             - '@translator'
         tags:
-            - { name: form.type, alias: sam_copy_role_by_application }
+            - { name: form.type }

--- a/Tests/ApplicationVoterTest.php
+++ b/Tests/ApplicationVoterTest.php
@@ -6,7 +6,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Tests\Authorization\Voter\RoleVoterTest;
 use CanalTP\SamEcoreSecurityBundle\Security\Authorization\Voter\ApplicationVoter;
 
-class ApllicationVoterTest extends RoleVoterTest
+class ApplicationVoterTest extends RoleVoterTest
 {
     /**
      * @dataProvider getVoteTests


### PR DESCRIPTION
fix 
```
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| #  | Usage                                                                                                                            | Line | Comment                                                                       |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Form/Type/Permission/ApplicationRoleType.php                                                                 |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 1  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                            | 32   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 2  | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\ApplicationRoleType->setDefaultOptions()        | 32   | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                                                  |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                                                  |      |  added to the FormTypeInterface with Symfony 3.0.                             |
| 3  | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\ApplicationRoleType->getName()                  | 43   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                                                  |      |  Use the fully-qualified class name of the type instead.                      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Form/Type/Permission/BusinessRightType.php                                                                   |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 4  | Using deprecated class Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList                                         | 49   | since Symfony 2.7, to be removed in version 3.0.                              |
|    |                                                                                                                                  |      |  Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList} instead.      |
| 5  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                            | 105  | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 6  | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\BusinessRightType->setDefaultOptions()          | 105  | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                                                  |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                                                  |      |  added to the FormTypeInterface with Symfony 3.0.                             |
| 7  | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Permission\BusinessRightType->getName()                    | 117  | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                                                  |      |  Use the fully-qualified class name of the type instead.                      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Form/Type/Role/CreateRoleType.php                                                                            |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 8  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                            | 38   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 9  | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CreateRoleType->setDefaultOptions()                   | 38   | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                                                  |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                                                  |      |  added to the FormTypeInterface with Symfony 3.0.                             |
| 10 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CreateRoleType->getName()                             | 48   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                                                  |      |  Use the fully-qualified class name of the type instead.                      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Form/Type/Role/CopyRoleByApplicationType.php                                                                 |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 11 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                            | 60   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 12 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CopyRoleByApplicationType->setDefaultOptions()        | 60   | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                                                  |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                                                  |      |  added to the FormTypeInterface with Symfony 3.0.                             |
| 13 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Role\CopyRoleByApplicationType->getName()                  | 70   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                                                  |      |  Use the fully-qualified class name of the type instead.                      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Form/Type/Role/RoleType.php                                                                                  |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 14 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                            | 39   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead. |
| 15 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Role\RoleType->setDefaultOptions()                         | 39   | since version 2.7, to be renamed in 3.0.                                      |
|    |                                                                                                                                  |      |  Use the method configureOptions instead. This method will be                 |
|    |                                                                                                                                  |      |  added to the FormTypeInterface with Symfony 3.0.                             |
| 16 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Form\Type\Role\RoleType->getName()                                   | 49   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                   |
|    |                                                                                                                                  |      |  Use the fully-qualified class name of the type instead.                      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Form/EventListener/CreateRoleListener.php                                                                    |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 17 | Using deprecated class Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList                                         | 57   | since Symfony 2.7, to be removed in version 3.0.                              |
|    |                                                                                                                                  |      |  Use {@link \Symfony\Component\Form\ChoiceList\ArrayChoiceList} instead.      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-security-manager-bundle/Security/Authorization/Voter/BusinessRightVoter.php                                                          |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
| 18 | Calling deprecated method Symfony\Component\Security\Core\Authorization\Voter\VoterInterface->supportsAttribute()                | 66   | since version 2.8, to be removed in 3.0.                                      |
| 19 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Security\Authorization\Voter\BusinessRightVoter->supportsAttribute() | 23   | since version 2.8, to be removed in 3.0.                                      |
| 20 | Overriding deprecated method CanalTP\SamEcoreSecurityBundle\Security\Authorization\Voter\BusinessRightVoter->supportsClass()     | 28   | since version 2.8, to be removed in 3.0.                                      |
+----+----------------------------------------------------------------------------------------------------------------------------------+------+-------------------------------------------------------------------------------+
```

Relates to https://github.com/CanalTP/SamEcoreUserManagerBundle/pull/25
https://jira.kisio.org/browse/GN-64