### PR TITLE
Fix namespace for test class

### DIFF
--- a/Tests/ApplicationVoterTest.php
+++ b/Tests/ApplicationVoterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CanalTP\SamEcoreSecurityBundle\Test;
+namespace CanalTP\SamEcoreSecurityManagerBundle\Test;
 
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Tests\Authorization\Voter\RoleVoterTest;


### PR DESCRIPTION
This PR fixes psr4 standard for autoloading in order to be compatible with future versions of composer

Issue link : BOT-2422